### PR TITLE
Tighten comments in sample app

### DIFF
--- a/template/src/app.ts
+++ b/template/src/app.ts
@@ -1,8 +1,5 @@
-// Import the Restate Typescript SDK
-// This imports the key parts of the SDK that you need to interact with.
 import * as restate from "@restatedev/restate-sdk";
 
-// Import the generated Protobuf code of the service contract
 import {
   ExampleService,
   SampleRequest,
@@ -10,34 +7,33 @@ import {
   protoMetadata,
 } from "./generated/proto/example";
 
-// An example of a service
+/*
+ * The example service here implements the interface generated from the 'example.proto' file.
+ */
 export class MyExampleService implements ExampleService {
-  // This example service implements a single method: `sampleCall`.
-  // The `sampleCall` method takes a `SampleRequest` and returns a `SampleResponse`, as defined in `proto/example.proto`.
-  // Other services will be able to call this method. You can also call it over gRPC or plain HTTP via the command line.
-  // A Restate service can contain multiple methods. A method can do arbitrarily anything as long as it is deterministic.
   async sampleCall(request: SampleRequest): Promise<SampleResponse> {
-    // The Restate context is the starting point of all interaction with the Restate runtime.
-    // Have a look at the Typescript SDK docs to know what you can do with the RestateContext: https://github.com/restatedev/documentation
+    // The Restate context is the entry point of all interaction with Restate, such as
+    // - RPCs:         `await (new AnotherServiceClientImpl(ctx)).myMethod(...)`
+    // - messagig:     `await ctx.inBackground(() => { (new AnotherServiceClientImpl).myMethod(...) } )`
+    // - state:        `await ctx.get<string>("myState")`
+    // - side-effects: `ctx.sideEffect(() => { runExternalStuff() })`
+    // - etc.
+    //
+    // Have a look at the TS docs or at https://github.com/restatedev/documentation
     const ctx = restate.useContext(this);
 
-    // Implement your service logic here...
+    // Service logic goes here...
 
-    // Return the response
     return SampleResponse.create({ response: "Hello " + request.request });
   }
 }
 
-// Create the Restate server to serve your methods
-// Bind the services that you implemented:
-// provide the name of the service as defined in `proto/example.proto`, an instance of the service implementation
-// and the generated protoMetadata.
-// Listen on the default port 8080 or any other port you specify.
+// Create the Restate server to accept requests to the service(s)
 restate
   .createServer()
   .bindService({
-    service: "ExampleService",
-    instance: new MyExampleService(),
-    descriptor: protoMetadata,
+    service: "ExampleService", // public name of the service, must match the name in the .proto definition
+    instance: new MyExampleService(), // the instance of the implementation
+    descriptor: protoMetadata, // the metadata (types, interfaces, ...) captured by the gRPC/protobuf compiler
   })
   .listen(8080);


### PR DESCRIPTION
This PR reduces the comments, to make the sample app look less overwhelming. I usually find minimal code that looks easy leaves a great first impression. For example, I think we don't need to explain mechanisms of gRPC and protobuf in the comments.
