### PR TITLE
Add bundle script for Lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ npm run app
 ```
 Your Restate service is now up and running!
 
+### Run the service on AWS Lambda
+To run the service as an AWS Lambda function, we need to upload it as a zip file on AWS.
+Create the zip file with:
+```shell
+npm run bundle
+```
+Make sure you create a Restate Lambda handler called `handler` in `src/app.ts`, instead of a Restate server. 
+
+Read the [Restate documentation](https://github.com/restatedev/documentation) for the details on AWS Lambda deployment.
 
 ## Launch the Restate Runtime and call the Service
 

--- a/template/package.json
+++ b/template/package.json
@@ -7,6 +7,9 @@
   "scripts": {
     "proto": "cd proto && npx buf mod update && npx buf generate .",
     "build": "tsc --noEmitOnError",
+    "prebundle": "rm -rf dist",
+    "bundle": "esbuild src/app.ts --bundle --minify --sourcemap --platform=node --target=es2020 --outfile=dist/index.js",
+    "postbundle": "cd dist && zip -r index.zip index.js*",
     "app": "node ./dist/app.js",
     "app-dev": "ts-node-dev --watch ./src --respawn --transpile-only ./src/app.ts"
   },


### PR DESCRIPTION
Running `npm run bundle` will build the service and creates a zip file.
This zipfile can be uploaded to AWS Lambda. 