### PR TITLE
Add esbuild to dev dependencies

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "ts-node-dev": "^1.1.1",
     "typescript": "^5.0.2",
-    "@bufbuild/buf": "1.15.0"
+    "@bufbuild/buf": "1.15.0",
+    "esbuild": "^0.18.12"
   }
 }


### PR DESCRIPTION
Adding esbuild to the dev dependencies to make `npm run bundle` work if esbuild hasn't been installed globally.