### PR TITLE
Update ports wrt to new model

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ This is a template for a [Restate-based](https://restate.dev/) service in [TypeS
 
 To create a template service, use this sequence of commands:
 
-> &#x1F4DD; Make sure you have set up your [access to Restate's packages](https://github.com/restatedev/restate-dist)
-while the system is still only accessible in private beta.
+> &#x1F4DD; Make sure you have set up your [access to Restate's packages](https://github.com/restatedev/restate-dist) while the system is still only accessible in private beta.
 
 ```shell
 npx -y @restatedev/create-app
@@ -53,17 +52,21 @@ We use the `@restatedev/create-app` template generator program. This gives you t
 Restate SDK dependency, (optionally a simple protobuf setup), and a sample application.
 
 For the default Restate API, use these commands:
+
 ```shell
 npx -y @restatedev/create-app
 cd restate-node-template
 ```
+
 For the gRPC-based API, use the following commands instead:
+
 ```shell
 npx -y @restatedev/create-app --grpc
 cd restate-node-grpc-template
 ```
 
 Next, install the dependencies:
+
 ```shell
 npm install
 ```
@@ -74,11 +77,12 @@ Restate services are RPC handlers, and can optionally be defined in [gRPC](https
 If you used the `--grpc` flag when generating the template, you have a `proto` folder with a sample gRPC service definition (`example.proto` is the main file, the others are for the proto compiler tool).
 
 To generate the TypeScript interfaces for the services, run:
+
 ```
 npm run proto
 ```
 
-### Implement, build, and run 
+### Implement, build, and run
 
 The example in `src/app.ts` shows the basic outline of a Restate-based service/app.
 
@@ -87,13 +91,14 @@ with names and routes when setting up the service's http2 server. For the gRPC-b
 interfaces generated from the gRPC .proto file.
 
 Once you are done with the implementation, build/run the app with:
+
 ```
 npm run build
 npm run app
 ```
-Your Restate service is now up and running! You can also run in incremental-recompile-on-edit mode via
-`npm run app-dev`. 
 
+Your Restate service is now up and running! You can also run in incremental-recompile-on-edit mode via
+`npm run app-dev`.
 
 ## Run a full setup locally
 
@@ -102,10 +107,13 @@ Your Restate service is now up and running! You can also run in incremental-reco
 Have a look at how to start up the runtime in a Docker container in this repository: https://github.com/restatedev/restate-dist or simply run the following commands:
 
 - For MacOS:
+
 ```shell
-docker run --name restate_dev --rm -p 8081:8081 -p 9091:9091 -p 9090:9090 ghcr.io/restatedev/restate-dist:latest
+docker run --name restate_dev --rm -p 8080:8080 -p 9070:9070 -p 9071:9071 ghcr.io/restatedev/restate-dist:latest
 ```
+
 - For Linux:
+
 ```shell
 docker run --name restate_dev --rm --network=host ghcr.io/restatedev/restate-dist:latest
 ```
@@ -115,12 +123,15 @@ docker run --name restate_dev --rm --network=host ghcr.io/restatedev/restate-dis
 Once the runtime is up, let it discover your services by executing:
 
 - For macOS:
+
 ```shell
-curl -X POST http://localhost:8081/endpoints -H 'content-type: application/json' -d '{"uri": "http://host.docker.internal:8080"}'
+curl -X POST http://localhost:9070/endpoints -H 'content-type: application/json' -d '{"uri": "http://host.docker.internal:9080"}'
 ```
+
 - For Linux:
+
 ```shell
-curl -X POST http://localhost:8081/endpoints -H 'content-type: application/json' -d '{"uri": "http://localhost:8080"}'
+curl -X POST http://localhost:9070/endpoints -H 'content-type: application/json' -d '{"uri": "http://localhost:9080"}'
 ```
 
 ### Call the Service
@@ -128,13 +139,13 @@ curl -X POST http://localhost:8081/endpoints -H 'content-type: application/json'
 We can now invoke the sample method by executing:
 
 ```shell
-curl -X POST http://localhost:9090/myservice/hello -H 'content-type: application/json' -d '{"request": "Pete"}'
+curl -X POST http://localhost:8080/myservice/hello -H 'content-type: application/json' -d '{"request": "Pete"}'
 ```
 
 For the gRPC-based template, use the following command instead:
 
 ```shell
-curl -X POST http://localhost:9090/org.example.ExampleService/SampleCall -H 'content-type: application/json' -d '{"request": "Pete"}'
+curl -X POST http://localhost:8080/org.example.ExampleService/SampleCall -H 'content-type: application/json' -d '{"request": "Pete"}'
 ```
 
 You can see that we include the JSON encoded request body.
@@ -142,12 +153,11 @@ When you are extending or adapting the service interface, adapt the method and r
 
 That's it! We managed to run a Restate service and invoke it!
 
-
 # Useful links
+
 - Restate Typescript SDK: https://github.com/restatedev/sdk-typescript
 - The Restate documentation: https://docs.restate.dev/
 - Restate Docker container: https://github.com/restatedev/restate-dist
-
 
 # Contributing to this template
 
@@ -159,12 +169,14 @@ Please take care to not commit unnecessary build artifacts when extending the te
 (and adjust `.gitignore` accordingly).
 
 ### Upgrading Typescript SDK
+
 - Upgrade the version tag in `template/package.json`
 - Test the template builds with `npm run build-templates`
 - Run the apps in the `/template` and `/template_grpc`directories to check if everything works: `npm run --prefix template app` `npm run --prefix template_grpc app`
 - Create a new release
 
 ### Upgrading Restate runtime
+
 Upgrade the version tag of the Restate runtime container image in this readme.
 
 ## Releasing
@@ -173,9 +185,8 @@ Upgrade the version tag of the Restate runtime container image in this readme.
 
 Releasing a new npm package from this repo requires:
 
-* [SSH access configured for Github](https://docs.github.com/en/authentication/connecting-to-github-with-ssh) in order to push commits and tags to GitHub
-* A GitHub personal access token with access to https://github.com/restatedev/node-template-generator in your environment as `GITHUB_TOKEN` in order to create a Github release
-
+- [SSH access configured for Github](https://docs.github.com/en/authentication/connecting-to-github-with-ssh) in order to push commits and tags to GitHub
+- A GitHub personal access token with access to https://github.com/restatedev/node-template-generator in your environment as `GITHUB_TOKEN` in order to create a Github release
 
 ```bash
 npm run release
@@ -191,4 +202,3 @@ The actual `npm publish` is run by GitHub actions once a GitHub release is creat
 3. [Create a new GitHub release](https://github.com/restatedev/node-template-generator/releases)
 
 Creating the GitHub release will trigger `npm publish` via GitHub actions.
-

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -16,6 +16,6 @@ RUN npm run build
 RUN npm prune --production
 ENV NODE_ENV production
 
-EXPOSE 8080
+EXPOSE 9080
 USER node
 CMD ["dumb-init", "node", "./dist/app.js"]

--- a/template/src/app.ts
+++ b/template/src/app.ts
@@ -23,7 +23,7 @@ restate
     "myservice", // the name of the service that serves the handlers
     restate.router({ hello: sayHello }) // the routes and handlers in the service
   )
-  .listen(8080);
+  .listen(9080);
 
 // --------------
 //  Testing this
@@ -31,14 +31,14 @@ restate
 //
 // Invoke this by calling Restate to invoke this handler durably:
 //
-//    curl -X POST -H 'content-type: application/json' http://localhost:9090/myservice/hello -d '{ "request": "Friend" }'
+//    curl -X POST -H 'content-type: application/json' http://localhost:8080/myservice/hello -d '{ "request": "Friend" }'
 //
 // To launch Restate and register this service (if you don't have Restate running already)
 //
 //  - On macOS:
-//    docker run --name restate_dev --rm -p 8081:8081 -p 9091:9091 -p 9090:9090 ghcr.io/restatedev/restate-dist:latest
-//    curl -X POST http://localhost:8081/endpoints -H 'content-type: application/json' -d '{"uri": "http://host.docker.internal:8080"}'
+//    docker run --name restate_dev --rm -p 8080:8080 -p 9070:9070 -p 9071:9071 ghcr.io/restatedev/restate-dist:latest
+//    curl -X POST http://localhost:9070/endpoints -H 'content-type: application/json' -d '{"uri": "http://host.docker.internal:9080"}'
 //
 //  - On Linux:
 //    docker run --name restate_dev --rm --network=host ghcr.io/restatedev/restate-dist:latest
-//    curl -X POST http://localhost:8081/endpoints -H 'content-type: application/json' -d '{"uri": "http://localhost:8080"}'
+//    curl -X POST http://localhost:9070/endpoints -H 'content-type: application/json' -d '{"uri": "http://localhost:9080"}'

--- a/template_grpc/Dockerfile
+++ b/template_grpc/Dockerfile
@@ -17,6 +17,6 @@ RUN npm run build
 RUN npm prune --production
 ENV NODE_ENV production
 
-EXPOSE 8080
+EXPOSE 9080
 USER node
 CMD ["dumb-init", "node", "./dist/app.js"]

--- a/template_grpc/src/app.ts
+++ b/template_grpc/src/app.ts
@@ -36,7 +36,7 @@ restate
     instance: new MyExampleService(), // the instance of the implementation
     descriptor: protoMetadata, // the metadata (types, interfaces, ...) captured by the gRPC/protobuf compiler
   })
-  .listen(8080);
+  .listen(9080);
 
 // --------------
 //  Testing this
@@ -44,14 +44,14 @@ restate
 //
 // Invoke this by calling Restate to invoke this handler durably:
 //
-//    curl -X POST -H 'content-type: application/json' http://localhost:9090/org.example.ExampleService/SampleCall -d '{ "request": "Friend" }'
+//    curl -X POST -H 'content-type: application/json' http://localhost:8080/org.example.ExampleService/SampleCall -d '{ "request": "Friend" }'
 //
 // To launch Restate and register this service (if you don't have Restate running already)
 //
 //  - On macOS:
-//    docker run --name restate_dev --rm -p 8081:8081 -p 9091:9091 -p 9090:9090 ghcr.io/restatedev/restate-dist:latest
-//    curl -X POST http://localhost:8081/endpoints -H 'content-type: application/json' -d '{"uri": "http://host.docker.internal:8080"}'
+//    docker run --name restate_dev --rm -p 8080:8080 -p 9070:9070 -p 9071:9071 ghcr.io/restatedev/restate-dist:latest
+//    curl -X POST http://localhost:9070/endpoints -H 'content-type: application/json' -d '{"uri": "http://host.docker.internal:9080"}'
 //
 //  - On Linux:
 //    docker run --name restate_dev --rm --network=host ghcr.io/restatedev/restate-dist:latest
-//    curl -X POST http://localhost:8081/endpoints -H 'content-type: application/json' -d '{"uri": "http://localhost:8080"}'
+//    curl -X POST http://localhost:9070/endpoints -H 'content-type: application/json' -d '{"uri": "http://localhost:9080"}'


### PR DESCRIPTION
This commit updates the ports in the node template generator so that it is in line with restatedev/restate#789.

This fixes #14.

This PR should be merged once Restate `0.4.0` is being released.