### PR TITLE
Alpha npm run dev functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,16 +3,6 @@ node_modules
 data/node-template.zip
 data/node-grpc-template.zip
 
-# dependencies and build artifacts in template 
-template/node_modules
-template/dist
-template/package-lock.json
-template_grpc/node_modules
-template_grpc/dist
-template_grpc/src/generated
-template_grpc/package-lock.json
-template_grpc/proto/buf.lock
-
 # IDE files
 .idea
 
@@ -21,3 +11,6 @@ npm-debug.log*
 *.tsbuildinfo
 .npm
 .eslintcache
+
+package-lock.json
+buf.lock

--- a/template/.gitignore
+++ b/template/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+target

--- a/template/package.json
+++ b/template/package.json
@@ -10,12 +10,19 @@
     "bundle": "esbuild src/app.ts --bundle --minify --sourcemap --platform=node --target=es2020 --outfile=dist/index.js",
     "postbundle": "cd dist && zip -r index.zip index.js*",
     "app": "node ./dist/app.js",
-    "app-dev": "ts-node-dev --watch ./src --respawn --transpile-only ./src/app.ts"
+    "app-dev": "ts-node-dev --watch ./src --respawn --transpile-only ./src/app.ts",
+    "restate-dev": "restate-server --wipe all",
+    "discover-dev": "wait-on http://localhost:9070/health tcp:9080 && restate services discover -y http://localhost:9080",
+    "dev": "concurrently --no-color npm:restate-dev npm:app-dev npm:discover-dev"
   },
   "dependencies": {
     "@restatedev/restate-sdk": "^0.5.1"
   },
   "devDependencies": {
+    "@restatedev/restate-server": "^0.5.1",
+    "@restatedev/restate": "^0.5.1",
+    "concurrently": "^8.2.2",
+    "wait-on": "^7.2.0",
     "ts-node-dev": "^1.1.1",
     "typescript": "^5.0.2",
     "esbuild": "^0.18.12"

--- a/template_grpc/.gitignore
+++ b/template_grpc/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+src/generated
+target

--- a/template_grpc/package.json
+++ b/template_grpc/package.json
@@ -11,7 +11,10 @@
     "bundle": "esbuild src/app.ts --bundle --minify --sourcemap --platform=node --target=es2020 --outfile=dist/index.js",
     "postbundle": "cd dist && zip -r index.zip index.js*",
     "app": "node ./dist/app.js",
-    "app-dev": "ts-node-dev --watch ./src --respawn --transpile-only ./src/app.ts"
+    "app-dev": "ts-node-dev --watch ./src --respawn --transpile-only ./src/app.ts",
+    "restate-dev": "restate-server --wipe all",
+    "discover-dev": "wait-on http://localhost:9070/health tcp:9080 && restate services discover -y http://localhost:9080",
+    "dev": "concurrently --no-color npm:restate-dev npm:app-dev npm:discover-dev"
   },
   "dependencies": {
     "@restatedev/restate-sdk": "^0.5.1",
@@ -19,6 +22,10 @@
     "ts-proto": "^1.140.0"
   },
   "devDependencies": {
+    "@restatedev/restate-server": "^0.5.1",
+    "@restatedev/restate": "^0.5.1",
+    "concurrently": "^8.2.2",
+    "wait-on": "^7.2.0",
     "ts-node-dev": "^1.1.1",
     "typescript": "^5.0.2",
     "@bufbuild/buf": "1.15.0",


### PR DESCRIPTION
npm run dev in this case starts a blank restate, the service, and discovers the service once Later on we probably want this to watch for schema changes and rediscover.