### PR TITLE
Example of test using testcontainers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ template/package-lock.json
 template_grpc/node_modules
 template_grpc/dist
 template_grpc/src/generated
+template_grpc/test/generated
 template_grpc/package-lock.json
 template_grpc/proto/buf.lock
 

--- a/template_grpc/.dockerignore
+++ b/template_grpc/.dockerignore
@@ -2,4 +2,5 @@
 node_modules
 dist
 src/generated
+test/generated
 Dockerfile

--- a/template_grpc/jest.config.js
+++ b/template_grpc/jest.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  roots: ["<rootDir>/test"],
+  testMatch: ["**/?(*.)+(spec|test).+(ts|tsx|js)"],
+  transform: {
+    "^.+\\.(ts|tsx)$": "ts-jest",
+  },
+  preset: "ts-jest",
+  testEnvironment: "node",
+};

--- a/template_grpc/package.json
+++ b/template_grpc/package.json
@@ -11,7 +11,8 @@
     "bundle": "esbuild src/app.ts --bundle --minify --sourcemap --platform=node --target=es2020 --outfile=dist/index.js",
     "postbundle": "cd dist && zip -r index.zip index.js*",
     "app": "node ./dist/app.js",
-    "app-dev": "ts-node-dev --watch ./src --respawn --transpile-only ./src/app.ts"
+    "app-dev": "ts-node-dev --watch ./src --respawn --transpile-only ./src/app.ts",
+    "test": "DEBUG=testcontainers,testcontainers:exec,testcontainers:containers jest --maxWorkers=1 --detectOpenHandles"
   },
   "dependencies": {
     "@restatedev/restate-sdk": "^0.6.0",
@@ -19,9 +20,17 @@
     "ts-proto": "^1.140.0"
   },
   "devDependencies": {
+    "@bufbuild/buf": "^1.15.0",
+    "@bufbuild/protobuf": "^1.6.0",
+    "@bufbuild/protoc-gen-es": "^1.6.0",
+    "@connectrpc/connect": "^1.2.0",
+    "@connectrpc/connect-node": "^1.2.0",
+    "@connectrpc/protoc-gen-connect-es": "^1.2.0",
+    "@types/jest": "^29.4.0",
+    "esbuild": "^0.18.12",
+    "testcontainers": "^10.4.0",
+    "ts-jest": "^29.0.5",
     "ts-node-dev": "^1.1.1",
-    "typescript": "^5.0.2",
-    "@bufbuild/buf": "1.15.0",
-    "esbuild": "^0.18.12"
+    "typescript": "^5.0.2"
   }
 }

--- a/template_grpc/proto/buf.gen.yaml
+++ b/template_grpc/proto/buf.gen.yaml
@@ -8,3 +8,10 @@ plugins:
   - plugin: buf.build/community/stephenh-ts-proto:v1.145.0
     out: ../src/generated/proto
     opt: outputSchema=true,env=node,esModuleInterop=true,lowerCaseServiceMethods=true,paths=source_relative,useExactTypes=false
+  # For testing code
+  - plugin: es
+    opt: target=ts
+    out: ../test/generated
+  - plugin: connect-es
+    opt: target=ts
+    out: ../test/generated

--- a/template_grpc/src/app.ts
+++ b/template_grpc/src/app.ts
@@ -1,43 +1,17 @@
 import * as restate from "@restatedev/restate-sdk";
 
-import {
-  ExampleService,
-  SampleRequest,
-  SampleResponse,
-  protoMetadata,
-} from "./generated/proto/example";
-
-/*
- * The example service here implements the interface generated from the 'example.proto' file.
- */
-export class MyExampleService implements ExampleService {
-  async sampleCall(request: SampleRequest): Promise<SampleResponse> {
-    // The Restate context is the entry point of all interaction with Restate, such as
-    // - RPCs:         `await (new AnotherServiceClientImpl(ctx)).myMethod(...)`
-    // - messaging:    `await ctx.oneWayCall(() => { (new AnotherServiceClientImpl(ctx)).myMethod(...) } )`
-    // - state:        `await ctx.get<string>("myState")`
-    // - side-effects: `await ctx.sideEffect(() => { runExternalStuff() })`
-    // - etc.
-    //
-    // Have a look at the TS docs or at https://github.com/restatedev/documentation
-    const ctx = restate.useContext(this);
-
-    // Service logic goes here...
-
-    return SampleResponse.create({ response: "Hello " + request.request });
-  }
-}
+import { protoMetadata } from "./generated/proto/example";
+import { MyExampleService } from "./example_service";
 
 // Create the Restate server to accept requests to the service(s)
-// TODO this should be in a separate file, otherwise it's loaded together when loading this module!
-// restate
-//   .createServer()
-//   .bindService({
-//     service: "ExampleService", // public name of the service, must match the name in the .proto definition
-//     instance: new MyExampleService(), // the instance of the implementation
-//     descriptor: protoMetadata, // the metadata (types, interfaces, ...) captured by the gRPC/protobuf compiler
-//   })
-//   .listen(9080);
+restate
+  .createServer()
+  .bindService({
+    service: "ExampleService", // public name of the service, must match the name in the .proto definition
+    instance: new MyExampleService(), // the instance of the implementation
+    descriptor: protoMetadata, // the metadata (types, interfaces, ...) captured by the gRPC/protobuf compiler
+  })
+  .listen(9080);
 
 // --------------
 //  Testing this

--- a/template_grpc/src/app.ts
+++ b/template_grpc/src/app.ts
@@ -29,14 +29,15 @@ export class MyExampleService implements ExampleService {
 }
 
 // Create the Restate server to accept requests to the service(s)
-restate
-  .createServer()
-  .bindService({
-    service: "ExampleService", // public name of the service, must match the name in the .proto definition
-    instance: new MyExampleService(), // the instance of the implementation
-    descriptor: protoMetadata, // the metadata (types, interfaces, ...) captured by the gRPC/protobuf compiler
-  })
-  .listen(9080);
+// TODO this should be in a separate file, otherwise it's loaded together when loading this module!
+// restate
+//   .createServer()
+//   .bindService({
+//     service: "ExampleService", // public name of the service, must match the name in the .proto definition
+//     instance: new MyExampleService(), // the instance of the implementation
+//     descriptor: protoMetadata, // the metadata (types, interfaces, ...) captured by the gRPC/protobuf compiler
+//   })
+//   .listen(9080);
 
 // --------------
 //  Testing this

--- a/template_grpc/src/example_service.ts
+++ b/template_grpc/src/example_service.ts
@@ -1,0 +1,28 @@
+import * as restate from "@restatedev/restate-sdk";
+
+import {
+  ExampleService,
+  SampleRequest,
+  SampleResponse,
+} from "./generated/proto/example";
+
+/*
+ * The example service here implements the interface generated from the 'example.proto' file.
+ */
+export class MyExampleService implements ExampleService {
+  async sampleCall(request: SampleRequest): Promise<SampleResponse> {
+    // The Restate context is the entry point of all interaction with Restate, such as
+    // - RPCs:         `await (new AnotherServiceClientImpl(ctx)).myMethod(...)`
+    // - messaging:    `await ctx.oneWayCall(() => { (new AnotherServiceClientImpl(ctx)).myMethod(...) } )`
+    // - state:        `await ctx.get<string>("myState")`
+    // - side-effects: `await ctx.sideEffect(() => { runExternalStuff() })`
+    // - etc.
+    //
+    // Have a look at the TS docs or at https://github.com/restatedev/documentation
+    const ctx = restate.useContext(this);
+
+    // Service logic goes here...
+
+    return SampleResponse.create({ response: "Hello " + request.request });
+  }
+}

--- a/template_grpc/test/test.ts
+++ b/template_grpc/test/test.ts
@@ -1,113 +1,134 @@
-import {GenericContainer, StartedTestContainer, TestContainers, Wait} from "testcontainers";
 import * as restate from "@restatedev/restate-sdk";
-import {protoMetadata} from "../src/generated/proto/example";
-import {MyExampleService} from "../src/app";
-import {createPromiseClient, Transport} from "@connectrpc/connect";
-import {createConnectTransport} from "@connectrpc/connect-node";
-import {ExampleService} from "./generated/example_connect";
+
+import {
+  GenericContainer,
+  StartedTestContainer,
+  TestContainers,
+  Wait,
+} from "testcontainers";
+import { createPromiseClient, Transport } from "@connectrpc/connect";
+import { createConnectTransport } from "@connectrpc/connect-node";
+import { ExampleService } from "./generated/example_connect";
 import * as http2 from "http2";
 import * as net from "net";
 
-async function prepareRestateServer(mountServicesFn: (server: restate.RestateServer) => void): Promise<http2.Http2Server> {
-    // Prepare RestateServer
-    const restateServer = restate.createServer()
-    mountServicesFn(restateServer);
+import { protoMetadata } from "../src/generated/proto/example";
+import { MyExampleService } from "../src/example_service";
 
-    // Start HTTP2 server on random port
-    const restateHttpServer = http2.createServer(restateServer);
-    await new Promise((resolve, reject) => {
-        restateHttpServer.listen(0)
-            .once('listening', resolve)
-            .once('error', reject);
-    });
-    const restateServerPort = (restateHttpServer.address() as net.AddressInfo).port;
-    console.info(`Started listening on port ${restateServerPort}`);
+async function prepareRestateServer(
+  mountServicesFn: (server: restate.RestateServer) => void
+): Promise<http2.Http2Server> {
+  // Prepare RestateServer
+  const restateServer = restate.createServer();
+  mountServicesFn(restateServer);
 
-    return restateHttpServer;
+  // Start HTTP2 server on random port
+  const restateHttpServer = http2.createServer(restateServer);
+  await new Promise((resolve, reject) => {
+    restateHttpServer
+      .listen(0)
+      .once("listening", resolve)
+      .once("error", reject);
+  });
+  const restateServerPort = (restateHttpServer.address() as net.AddressInfo)
+    .port;
+  console.info(`Started listening on port ${restateServerPort}`);
+
+  return restateHttpServer;
 }
 
-async function prepareRestateTestContainer(restateServerPort: number): Promise<StartedTestContainer> {
-    const restateContainer = new GenericContainer("docker.io/restatedev/restate:latest")
-        // Expose ports
-        .withExposedPorts(8080, 9070)
-        // Wait start on health checks
-        .withWaitStrategy(
-            Wait.forAll([
-                Wait.forHttp("/grpc.health.v1.Health/Check", 8080),
-                Wait.forHttp("/health", 9070),
-            ])
-        );
+async function prepareRestateTestContainer(
+  restateServerPort: number
+): Promise<StartedTestContainer> {
+  const restateContainer = new GenericContainer(
+    "docker.io/restatedev/restate:latest"
+  )
+    // Expose ports
+    .withExposedPorts(8080, 9070)
+    // Wait start on health checks
+    .withWaitStrategy(
+      Wait.forAll([
+        Wait.forHttp("/grpc.health.v1.Health/Check", 8080),
+        Wait.forHttp("/health", 9070),
+      ])
+    );
 
-    // This MUST be executed before starting the restate container
-    // Expose host port to access the restate server
-    await TestContainers.exposeHostPorts(restateServerPort);
+  // This MUST be executed before starting the restate container
+  // Expose host port to access the restate server
+  await TestContainers.exposeHostPorts(restateServerPort);
 
-    // Start restate container
-    const startedRestateContainer = await restateContainer.start();
+  // Start restate container
+  const startedRestateContainer = await restateContainer.start();
 
-    // From now on, if something fails, stop the container to cleanup the environment
-    try {
-        console.info("Going to register services");
+  // From now on, if something fails, stop the container to cleanup the environment
+  try {
+    console.info("Going to register services");
 
-        // Register this service endpoint
-        const res = await fetch(`http://${startedRestateContainer.getHost()}:${startedRestateContainer.getMappedPort(9070)}/endpoints`, {
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-                // See https://node.testcontainers.org/features/networking/#expose-host-ports-to-container
-                uri: `http://host.testcontainers.internal:${restateServerPort}`
-            }),
-        });
-        if (!res.ok) {
-            const badResponse = await res.text();
-            throw new Error(`Error ${res.status} during registration: ${badResponse}`)
-        }
-
-        console.info("Registered");
-        return startedRestateContainer;
-    } catch (e) {
-        await startedRestateContainer.stop();
-        throw e;
+    // Register this service endpoint
+    const res = await fetch(
+      `http://${startedRestateContainer.getHost()}:${startedRestateContainer.getMappedPort(
+        9070
+      )}/endpoints`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          // See https://node.testcontainers.org/features/networking/#expose-host-ports-to-container
+          uri: `http://host.testcontainers.internal:${restateServerPort}`,
+        }),
+      }
+    );
+    if (!res.ok) {
+      const badResponse = await res.text();
+      throw new Error(
+        `Error ${res.status} during registration: ${badResponse}`
+      );
     }
+
+    console.info("Registered");
+    return startedRestateContainer;
+  } catch (e) {
+    await startedRestateContainer.stop();
+    throw e;
+  }
 }
 
 describe("ExampleService", () => {
-    let startedRestateHttpServer: http2.Http2Server;
-    let startedRestateContainer: StartedTestContainer;
-    let clientTransport: Transport;
+  let startedRestateHttpServer: http2.Http2Server;
+  let startedRestateContainer: StartedTestContainer;
+  let clientTransport: Transport;
 
-    beforeAll(async () => {
-        startedRestateHttpServer = await prepareRestateServer(
-            (restateServer) => restateServer.bindService(
-                {
-                    service: "ExampleService",
-                    instance: new MyExampleService(),
-                    descriptor: protoMetadata,
-                }
-            )
-        );
+  beforeAll(async () => {
+    startedRestateHttpServer = await prepareRestateServer((restateServer) =>
+      restateServer.bindService({
+        service: "ExampleService",
+        instance: new MyExampleService(),
+        descriptor: protoMetadata,
+      })
+    );
 
-        startedRestateContainer = await prepareRestateTestContainer(
-            (startedRestateHttpServer.address() as net.AddressInfo).port
-        );
+    startedRestateContainer = await prepareRestateTestContainer(
+      (startedRestateHttpServer.address() as net.AddressInfo).port
+    );
 
-        clientTransport = createConnectTransport({
-            baseUrl: `http://${startedRestateContainer.getHost()}:${startedRestateContainer.getMappedPort(8080)}`,
-            httpVersion: "1.1"
-        });
-
-    }, 10_000);
-
-    afterAll(async () => {
-        await startedRestateContainer.stop()
-        startedRestateHttpServer.close();
+    clientTransport = createConnectTransport({
+      baseUrl: `http://${startedRestateContainer.getHost()}:${startedRestateContainer.getMappedPort(
+        8080
+      )}`,
+      httpVersion: "1.1",
     });
+  }, 10_000);
 
-    it("works", async () => {
-        const serviceClient = createPromiseClient(ExampleService, clientTransport);
-        const result = await serviceClient.sampleCall({request: "Francesco"});
-        expect(result.response).toBe("Hello Francesco");
-    });
+  afterAll(async () => {
+    await startedRestateContainer.stop();
+    startedRestateHttpServer.close();
+  });
+
+  it("works", async () => {
+    const serviceClient = createPromiseClient(ExampleService, clientTransport);
+    const result = await serviceClient.sampleCall({ request: "Francesco" });
+    expect(result.response).toBe("Hello Francesco");
+  });
 });

--- a/template_grpc/test/test.ts
+++ b/template_grpc/test/test.ts
@@ -1,0 +1,94 @@
+import {GenericContainer, StartedTestContainer, TestContainers, Wait} from "testcontainers";
+import * as restate from "@restatedev/restate-sdk";
+import {protoMetadata} from "../src/generated/proto/example";
+import {MyExampleService} from "../src/app";
+import {createPromiseClient, Transport} from "@connectrpc/connect";
+import {createConnectTransport} from "@connectrpc/connect-node";
+import {ExampleService} from "./generated/example_connect";
+
+async function prepareRestateTestEnvironment(mountServicesFn: (server: restate.RestateServer) => void): Promise<StartedTestContainer> {
+    const restateContainer = new GenericContainer("docker.io/restatedev/restate:latest")
+        // Expose ports
+        .withExposedPorts(8080, 9070)
+        // Wait start on health checks
+        .withWaitStrategy(
+            Wait.forAll([
+                Wait.forHttp("/grpc.health.v1.Health/Check", 8080),
+                Wait.forHttp("/health", 9070),
+            ])
+        );
+
+    // This MUST be executed before starting the restate container
+    // Expose host port to access the restate server
+    await TestContainers.exposeHostPorts(9080);
+
+    // Start restate container
+    const startedRestateContainer = await restateContainer.start();
+
+    // From now on, if something fails, stop the container to cleanup the environment
+    try {
+        const restateServer = restate.createServer()
+        mountServicesFn(restateServer);
+
+        // TODO bad, fix this once https://github.com/restatedev/sdk-typescript/issues/220 is done
+        // Also we have no way to stop this server :(
+        restateServer.listen(9080);
+
+        console.info("Going to register");
+
+        // Register this service endpoint
+        const res = await fetch(`http://${startedRestateContainer.getHost()}:${startedRestateContainer.getMappedPort(9070)}/endpoints`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                // See https://node.testcontainers.org/features/networking/#expose-host-ports-to-container
+                uri: "http://host.testcontainers.internal:9080"
+            }),
+        });
+        if (!res.ok) {
+            const badResponse = await res.text();
+            throw new Error(`Error ${res.status} during registration: ${badResponse}`)
+        }
+
+        console.info("Registered");
+        return startedRestateContainer;
+    } catch (e) {
+        await startedRestateContainer.stop();
+        throw e;
+    }
+}
+
+describe("ExampleService", () => {
+    let startedRestateContainer: StartedTestContainer;
+    let clientTransport: Transport;
+
+    beforeAll(async () => {
+        startedRestateContainer = await prepareRestateTestEnvironment(
+            (restateServer) => restateServer.bindService(
+                {
+                    service: "ExampleService",
+                    instance: new MyExampleService(),
+                    descriptor: protoMetadata,
+                }
+            )
+        );
+
+        clientTransport = createConnectTransport({
+            baseUrl: `http://${startedRestateContainer.getHost()}:${startedRestateContainer.getMappedPort(8080)}`,
+            httpVersion: "1.1"
+        });
+
+    }, 10_000);
+
+    afterAll(async () => {
+        await startedRestateContainer.stop()
+    });
+
+    it("works", async () => {
+        const serviceClient = createPromiseClient(ExampleService, clientTransport);
+        const result = await serviceClient.sampleCall({request: "Francesco"});
+        expect(result.response).toBe("Hello Francesco");
+    });
+});


### PR DESCRIPTION
Fix #18

This is an attempt to test services in unit tests using testcontainers to run restate. This is loosely inspired by sdk-java testing module ([usage](https://github.com/restatedev/examples/blob/main/java/hello-world-http/src/test/java/dev/restate/sdk/examples/GreeterTest.java) and [implementation](https://github.com/restatedev/sdk-java/blob/main/sdk-testing/src/main/java/dev/restate/sdk/testing/ManualRestateRunner.java)).

Unfortunately I still can't quite get it right due to https://github.com/restatedev/sdk-typescript/issues/220. Without a way to start and stop the server, the jest test won't finish.