### PR TITLE
Unify docker commands across MacOS and Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,42 +98,42 @@ npm run build
 npm run app
 ```
 
-Your Restate service is now up and running! You can also run in incremental-recompile-on-edit mode via
+Your Restate service deployment is now up and running! You can also run in incremental-recompile-on-edit mode via
 `npm run app-dev`.
 
 ## Run a full setup locally
 
-### Launch the Restate runtime
+### Launch the Restate Server
 
-Have a look at how to start up the runtime in [this repository](https://github.com/restatedev/restate) or run the following commands:
+Have a look at the options for downloading Restate [here](https://restate.dev/get-restate/) or run one of the following commands:
 
-- For MacOS:
+- To run Restate in a Docker container:
+    ```shell
+    docker run --name restate_dev --rm -p 8080:8080 -p 9070:9070 -p 9071:9071 --add-host=host.docker.internal:host-gateway docker.io/restatedev/restate:latest
+    ```
+- To run Restate with `npx`:
+    ```shell
+    npx @restatedev/restate-server@latest
+    ```
+- To run Restate with Homebrew:
+    ```
+    brew install restatedev/tap/restate-server
+    ```
 
-```shell
-docker run --name restate_dev --rm -p 8080:8080 -p 9070:9070 -p 9071:9071 docker.io/restatedev/restate:latest
-```
+### Register the service deployment in Restate
 
-- For Linux:
+Once Restate is up, register the service deployment in Restate by executing:
 
-```shell
-docker run --name restate_dev --rm --network=host docker.io/restatedev/restate:latest
-```
-
-### Connect Services and Runtime
-
-Once the runtime is up, let it discover your services by executing:
-
-- For macOS:
-
-```shell
-curl -X POST http://localhost:9070/deployments -H 'content-type: application/json' -d '{"uri": "http://host.docker.internal:9080"}'
-```
-
-- For Linux:
-
-```shell
-curl -X POST http://localhost:9070/deployments -H 'content-type: application/json' -d '{"uri": "http://localhost:9080"}'
-```
+- Via the [CLI](https://docs.restate.dev/restate/cli):
+    ```shell
+    restate dp register localhost:9080
+    ```
+  When running Restate with Docker, use `host.docker.internal` instead of `localhost` for the service deployment URI.
+- Via `curl`:
+    ```shell
+    curl localhost:9070/deployments  -H 'content-type: application/json' -d '{"uri": "http://localhost:9080"}'
+    ```
+  When running Restate with Docker, use `host.docker.internal` instead of `localhost` for the service deployment URI.
 
 ### Call the Service
 

--- a/template/src/app.ts
+++ b/template/src/app.ts
@@ -12,33 +12,31 @@ import * as restate from "@restatedev/restate-sdk";
 //
 // Have a look at the TS docs on the context, or at https://docs.restate.dev/
 //
-const sayHello = async (ctx: restate.RpcContext, name: string) => {
-  return `Hello ${name}!`;
-};
+// The routes and handlers in the service
+const router = restate.router({
+  hello: async (ctx: restate.RpcContext, name: string) => {
+    return `Hello ${name}!`;
+  }
+});
+
+// The name of the service that serves the handlers
+// You can use this to call this service from other services
+export const service: restate.ServiceApi<typeof router> = { path: "myservice" }
 
 // Create the Restate server to accept requests
 restate
   .createServer()
-  .bindRouter(
-    "myservice", // the name of the service that serves the handlers
-    restate.router({ hello: sayHello }) // the routes and handlers in the service
-  )
+  .bindRouter(service.path, router)
   .listen(9080);
 
 // --------------
 //  Testing this
 // --------------
-//
-// Invoke this by calling Restate to invoke this handler durably:
-//
-//    curl -X POST -H 'content-type: application/json' http://localhost:8080/myservice/hello -d '{ "request": "Friend" }'
+// Have a look at the quickstart guide at https://docs.restate.dev/quickstart/
 //
 // To launch Restate and register this service (if you don't have Restate running already)
+//    docker run --name restate_dev --rm -p 8080:8080 -p 9070:9070 -p 9071:9071 --add-host=host.docker.internal:host-gateway docker.io/restatedev/restate:latest
+//    curl localhost:9070/deployments  -H 'content-type: application/json' -d '{"uri": "http://host.docker.internal:9080"}'
 //
-//  - On macOS:
-//    docker run --name restate_dev --rm -p 8080:8080 -p 9070:9070 -p 9071:9071 docker.io/restatedev/restate:latest
-//    curl -X POST http://localhost:9070/deployments -H 'content-type: application/json' -d '{"uri": "http://host.docker.internal:9080"}'
-//
-//  - On Linux:
-//    docker run --name restate_dev --rm --network=host docker.io/restatedev/restate:latest
-//    curl -X POST http://localhost:9070/deployments -H 'content-type: application/json' -d '{"uri": "http://localhost:9080"}'
+// Invoke this by calling Restate to invoke this handler durably:
+//    curl localhost:8080/myservice/hello -H 'content-type: application/json' -d '{ "request": "Friend" }'

--- a/template_grpc/src/app.ts
+++ b/template_grpc/src/app.ts
@@ -42,16 +42,12 @@ restate
 //  Testing this
 // --------------
 //
+// Have a look at the quickstart guide at https://docs.restate.dev/quickstart/
+//
+// To launch Restate and register this service (if you don't have Restate running already)
+//    docker run --name restate_dev --rm -p 8080:8080 -p 9070:9070 -p 9071:9071 --add-host=host.docker.internal:host-gateway docker.io/restatedev/restate:latest
+//    curl localhost:9070/deployments  -H 'content-type: application/json' -d '{"uri": "http://host.docker.internal:9080"}'
+//
 // Invoke this by calling Restate to invoke this handler durably:
 //
 //    curl -X POST -H 'content-type: application/json' http://localhost:8080/org.example.ExampleService/SampleCall -d '{ "request": "Friend" }'
-//
-// To launch Restate and register this service (if you don't have Restate running already)
-//
-//  - On macOS:
-//    docker run --name restate_dev --rm -p 8080:8080 -p 9070:9070 -p 9071:9071 docker.io/restatedev/restate:latest
-//    curl -X POST http://localhost:9070/deployments -H 'content-type: application/json' -d '{"uri": "http://host.docker.internal:9080"}'
-//
-//  - On Linux:
-//    docker run --name restate_dev --rm --network=host docker.io/restatedev/restate:latest
-//    curl -X POST http://localhost:9070/deployments -H 'content-type: application/json' -d '{"uri": "http://localhost:9080"}'


### PR DESCRIPTION
Fixes https://github.com/restatedev/documentation/issues/289

- Unify docker run commands across OS
- Update registration command
- Improving structure of greeter